### PR TITLE
Add page for Browser new tab

### DIFF
--- a/pages/new-tab.js
+++ b/pages/new-tab.js
@@ -1,0 +1,13 @@
+export default function NewTab() {
+  return (
+    <div className="w-full h-full flex justify-center items-center">
+      <div className="text-center">
+        <img src="/logo.svg" className="inline-block m-8 h-12 w-12" />
+        <h1 style={{ width: 420 }} className="text-xl text-gray-600">
+          Please navigate to the page you want to record, then press the blue
+          record button.
+        </h1>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
If we plan to keep this on the website, we'll likely want to create a "private" subdirectory for Replay browser files to keep things organized and avoid polluting the root directory. I think this is okay for now but wanted to open up the conversation.