### PR TITLE
Add redirects for new paths in DevTools

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,41 +1,52 @@
+const devToolsHost =
+  process.env.REPLAY_DEVTOOLS_HOST || "https://dc3tvimjwmdjm.cloudfront.net";
 const directories = ["dist", "images", "downloads", "driver", "protocol"];
-const files = ["view"];
+const files = ["view", "browser"];
 
 const rewrites = [];
 const headers = [];
 
 rewrites.push({
   source: `/protocol/tot/:domain`,
-  destination: `https://dc3tvimjwmdjm.cloudfront.net/protocol/tot/:domain/`,
+  destination: `${devToolsHost}/protocol/tot/:domain/`
 });
 
 rewrites.push({
   source: "/discord",
-  destination: "https://discord.gg/PFjtU3uv7M",
+  destination: "https://discord.gg/PFjtU3uv7M"
 });
 
 for (const directory of directories) {
   headers.push({
     source: `/${directory}/:rest*`,
-    headers: [{ key: "cache-control", value: "s-maxage=1" }],
+    headers: [{ key: "cache-control", value: "s-maxage=1" }]
   });
 
   rewrites.push({
     source: `/${directory}/:rest*`,
-    destination: `https://dc3tvimjwmdjm.cloudfront.net/${directory}/:rest*`,
+    destination: `${devToolsHost}/${directory}/:rest*`
   });
 }
 
 for (const file of files) {
   headers.push({
     source: `/${file}`,
-    headers: [{ key: "cache-control", value: "s-maxage=0" }],
+    headers: [{ key: "cache-control", value: "s-maxage=0" }]
   });
 
   rewrites.push({
-    source: `/${file}`,
-    destination: `https://dc3tvimjwmdjm.cloudfront.net/${file}`,
+    source: `/${file}/:rest*`,
+    destination: `${devToolsHost}/${file}/:rest*`
   });
+
+  // rewrite root directories when requested within child paths of each $file
+  // /view/recordings/123-456-789/images/logo.svg => /images/logo.svg
+  for (const directory of directories) {
+    rewrites.push({
+      source: `/${file}/:path*/${directory}/:rest*`,
+      destination: `${devToolsHost}/${directory}/:rest*`
+    });
+  }
 }
 
 module.exports = {
@@ -44,5 +55,5 @@ module.exports = {
   },
   headers() {
     return headers;
-  },
+  }
 };


### PR DESCRIPTION
Adds redirects for directories so requests for them from child paths (e.g. `/browser/error`) will resolve correctly