### PR TITLE
Remove animations to avoid triggering tons of repaints

### DIFF
--- a/components/TicTacToe.tsx
+++ b/components/TicTacToe.tsx
@@ -216,7 +216,7 @@ const TicTacToe: React.FC = () => {
       <div className="relative w-64 ml-8 text-left">
         {showMessage && (
           <div className="message-box">
-            <div className="mb-4 text-2xl font-bold animated-gradient-text">
+            <div className="mb-4 text-2xl font-bold gradient-text">
               {header}
             </div>
             <p className="text-xl">{message}</p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,10 +32,6 @@ a {
   text-decoration: underline;
 }
 
-.box.animate {
-  animation: bg-spin 3s linear infinite;
-}
-
 @keyframes gradient-flow {
   0% {
     background-position: 0% 50%;
@@ -55,7 +51,6 @@ a {
   color: white;
   background: linear-gradient(90deg, #ff6a00, #ee0979, #ff6a00);
   background-size: 200% 200%;
-  animation: gradient-flow 6s ease infinite;
   border: none;
   border-radius: 64px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -64,26 +59,24 @@ a {
   transition: opacity 0.5s ease-in-out;
 }
 
-.animated-gradient-text {
+.gradient-text {
   background: linear-gradient(90deg, #ff6a00, #ee0979, #ff6a00);
   background-size: 200% 200%;
   color: transparent;
   -webkit-background-clip: text;
   background-clip: text;
-  animation: gradient-flow 4s ease infinite;
 }
 
 .success-color {
   color: #ee0979;
 }
 
-.animated-gradient-text-2 {
+.gradient-text-2 {
   background: linear-gradient(90deg, #0077b6, #0096c7, #00b4d8, #030ea3);
   background-size: 200% 200%;
   color: transparent;
   -webkit-background-clip: text;
   background-clip: text;
-  animation: gradient-flow 4s ease infinite;
   font-weight: medium;
 }
 
@@ -118,8 +111,4 @@ a {
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.animated-entrance {
-  animation: fadeInUp 0.5s ease-out forwards;
 }


### PR DESCRIPTION
These animations were making recordings slow and (subjectively) weren't adding enough value to justify how much they were impacting replay performance.

Compare the number of repaints [before (go/r/79d2ebdc)](https://app.replay.io/recording/pro-574-with-animations--79d2ebdc-12af-457c-818c-29ce4663e688) to [after (go/r/b840c833)](https://app.replay.io/recording/b840c833-ddf1-45b6-b643-2b07e6fb7161)

cc @jonbell-lot23